### PR TITLE
change the interval of the modifier's rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Fixed
 
 - Update internals (tracktion_engine 2.1).
+- Change the interval of the rate selector in modifiers for .5 instead of .1.
 
 ## [0.1.1] - 2022-06-15
 

--- a/Source/Modules/app_view_models/Edit/Modifiers/LFOModifierViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Modifiers/LFOModifierViewModel.cpp
@@ -89,7 +89,7 @@ double LFOModifierViewModel::getParameterInterval(int index) {
     case 0:
         return 1;
     case 1:
-        return .1;
+        return .5;
     case 2:
         return .01;
     case 3:


### PR DESCRIPTION
set .5 as interval since min is 0 and max is 50
This will make the rotary encoder more consistent with others relatively with their intervals


## Please fill in this pull request template before submitting

### 1. Description
(Write description of your changes here)

### 2. Fill in checklist by marking [x]
- [x] I've read the CONTRIBUTING.md
- [x] My code is formatted using required linting
- [x] I've run my code locally and checked it works
- [x] My code has unit tests associated with it (if applicable)
- [x] I've run the test suite locally and all tests pass