### PR TITLE
Arpnoia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cmake-build-release/
 
 *.vsidx
 .vs
+/out/install/x64-Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,14 @@ juce_add_gui_app(LMN-3
     # COMPANY_NAME ...                  # Specify the name of the app's author
     PRODUCT_NAME LMN-3         # The name of the final executable, which can differ from the target name
 )
+if (WIN32)
+  add_custom_command(TARGET LMN-3 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      $<TARGET_RUNTIME_DLLS:LMN-3>
+      $<TARGET_FILE_DIR:LMN-3>
+    COMMAND_EXPAND_LISTS
+  )
+endif()
 
 target_compile_features(LMN-3  PRIVATE cxx_std_20)
 
@@ -93,7 +101,7 @@ target_sources(LMN-3  PRIVATE
     Source/Views/Edit/Mixer/MixerTableListBoxModel.cpp
     Source/Views/Edit/Mixer/MixerTrackView.cpp
     Source/Views/Edit/Mixer/LevelMeterComponent.cpp
-)
+ "Source/Modules/app_view_models/Edit/Plugins/FourOsc/ArpeggiatorViewModel.h" "Source/Views/Edit/Plugins/FourOsc/ArpeggiatorView.cpp" "Source/Views/Edit/Plugins/FourOsc/ArpeggiatorView.h")
 
 target_include_directories(LMN-3  PUBLIC
     Source/
@@ -193,10 +201,14 @@ target_link_libraries(LMN-3
         FontData
     #    SynthSampleData
     #    DrumSampleData
-        atomic
+    #    atomic
         yaml-cpp
     PUBLIC
         juce::juce_recommended_config_flags
         juce::juce_recommended_lto_flags
         juce::juce_recommended_warning_flags
 )
+if (NOT MSVC)
+  target_link_libraries(LMN-3 PRIVATE atomic)
+endif()
+

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -45,6 +45,8 @@ class GuiAppApplication : public juce::JUCEApplication {
         // we need to add the app internal plugins to the cache:
         engine.getPluginManager()
             .createBuiltInType<internal_plugins::DrumSamplerPlugin>();
+        engine.getPluginManager()
+            .createBuiltInType<internal_plugins::CustomFourOscPlugin>();
 
         // this can cache all your plugins.
         /* auto &knownPluginList = engine.getPluginManager().knownPluginList;

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -170,6 +170,30 @@ class GuiAppApplication : public juce::JUCEApplication {
         if (result != "") {
             juce::Logger::writeToLog(
                 "Attempt to initialise default devices failed!");
+            return;
+        }
+
+        auto savedOutput = ConfigurationHelpers::getSavedOutputDevice();
+        if (savedOutput.isNotEmpty()) {
+            auto availableOutputs =
+                deviceManager.getCurrentDeviceTypeObject()->getDeviceNames();
+            if (availableOutputs.contains(savedOutput)) {
+                auto setup = deviceManager.getAudioDeviceSetup();
+                setup.outputDeviceName = savedOutput;
+                auto setResult = deviceManager.setAudioDeviceSetup(setup, true);
+                if (setResult != "") {
+                    juce::Logger::writeToLog(
+                        "Failed to apply saved output device '" + savedOutput +
+                        "': " + setResult);
+                } else {
+                    juce::Logger::writeToLog("Applied saved output device: " +
+                                             savedOutput);
+                }
+            } else {
+                juce::Logger::writeToLog(
+                    "Saved output device not found, using default: " +
+                    savedOutput);
+            }
         }
     }
     void shutdown() override {

--- a/Source/Modules/app_configuration/ConfigurationHelpers.h
+++ b/Source/Modules/app_configuration/ConfigurationHelpers.h
@@ -20,6 +20,8 @@ class ConfigurationHelpers {
     static void setSavedTrackName(const juce::File &newValue);
     static juce::File getSavedTrackName();
     static juce::String getApplicationName();
+    static juce::String getSavedOutputDevice();
+    static void setSavedOutputDevice(const juce::String &deviceName);
 
   private:
     static bool writeBinarySamplesToDirectory(const juce::File &destDir,

--- a/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.cpp
+++ b/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.cpp
@@ -48,7 +48,12 @@ void MidiCommandManager::handleIncomingMidiMessage(
 void MidiCommandManager::midiMessageReceived(const juce::MidiMessage &message,
                                              const juce::String & /*source*/) {
     juce::Logger::writeToLog(getMidiMessageDescription(message));
-
+    
+    if (message.isNoteOff()) {
+        if (auto listener = dynamic_cast<Listener *>(focusedComponent))
+            listener->noteOffPressed(message.getNoteNumber());
+        return;
+    }
     if (message.isNoteOn()) {
         if (auto listener = dynamic_cast<Listener *>(focusedComponent))
             listener->noteOnPressed(message.getNoteNumber());

--- a/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.h
+++ b/Source/Modules/app_services/MidiCommandManager/MidiCommandManager.h
@@ -21,6 +21,7 @@ class MidiCommandManager : private juce::MidiInputCallback {
         virtual void controllerEventReceived(int, int) {}
 
         virtual void noteOnPressed(int /*noteNumber*/) {}
+        virtual void noteOffPressed(int /*noteNumber*/) {}
 
         virtual void encoder1Increased() {}
         virtual void encoder1Decreased() {}

--- a/Source/Modules/app_view_models/Edit/Plugins/FourOsc/ArpeggiatorViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Plugins/FourOsc/ArpeggiatorViewModel.cpp
@@ -1,0 +1,152 @@
+#include "ArpeggiatorViewModel.h"
+#include <internal_plugins/CustomFourOscPlugin/CustomFourOscPlugin.h>
+
+namespace app_view_models {
+
+ArpeggiatorViewModel::ArpeggiatorViewModel(
+    internal_plugins::CustomFourOscPlugin *p)
+    : plugin(p) {}
+
+void ArpeggiatorViewModel::addListener(Listener *l) {
+    listeners.add(l);
+    l->parametersChanged();
+}
+
+void ArpeggiatorViewModel::removeListener(Listener *l) { listeners.remove(l); }
+
+ArpeggiatorViewModel::Mode ArpeggiatorViewModel::getMode() const {
+    if (plugin == nullptr)
+        return Mode::off;
+
+    auto raw = juce::jlimit(0, static_cast<int>(Mode::random),
+                            plugin->getArpeggiatorMode());
+    return static_cast<Mode>(raw);
+}
+
+void ArpeggiatorViewModel::incrementMode() {
+    auto next = static_cast<int>(getMode()) + 1;
+    if (next > static_cast<int>(Mode::random))
+        next = static_cast<int>(Mode::off);
+    if (plugin != nullptr)
+        plugin->setArpeggiatorMode(next);
+    notifyParametersChanged();
+}
+
+void ArpeggiatorViewModel::decrementMode() {
+    auto next = static_cast<int>(getMode()) - 1;
+    if (next < static_cast<int>(Mode::off))
+        next = static_cast<int>(Mode::random);
+    if (plugin != nullptr)
+        plugin->setArpeggiatorMode(next);
+    notifyParametersChanged();
+}
+
+double ArpeggiatorViewModel::getRate() const {
+    if (plugin == nullptr)
+        return 4.0;
+
+    return plugin->getArpeggiatorRate();
+}
+
+void ArpeggiatorViewModel::incrementRate() {
+    auto newRate = juce::jlimit(1.0, 16.0, getRate() + 0.5);
+    if (plugin != nullptr)
+        plugin->setArpeggiatorRate(static_cast<float>(newRate));
+    notifyParametersChanged();
+}
+
+void ArpeggiatorViewModel::decrementRate() {
+    auto newRate = juce::jlimit(1.0, 16.0, getRate() - 0.5);
+    if (plugin != nullptr)
+        plugin->setArpeggiatorRate(static_cast<float>(newRate));
+    notifyParametersChanged();
+}
+
+int ArpeggiatorViewModel::getOctaves() const {
+    if (plugin == nullptr)
+        return 1;
+
+    return plugin->getArpeggiatorOctaves();
+}
+
+void ArpeggiatorViewModel::incrementOctaves() {
+    auto newValue = juce::jlimit(1, 4, getOctaves() + 1);
+    if (plugin != nullptr)
+        plugin->setArpeggiatorOctaves(newValue);
+    notifyParametersChanged();
+}
+
+void ArpeggiatorViewModel::decrementOctaves() {
+    auto newValue = juce::jlimit(1, 4, getOctaves() - 1);
+    if (plugin != nullptr)
+        plugin->setArpeggiatorOctaves(newValue);
+    notifyParametersChanged();
+}
+
+double ArpeggiatorViewModel::getGate() const {
+    if (plugin == nullptr)
+        return 0.5;
+
+    return plugin->getArpeggiatorGate();
+}
+
+void ArpeggiatorViewModel::incrementGate() {
+    auto newGate = juce::jlimit(0.05, 1.0, getGate() + 0.05);
+    if (plugin != nullptr)
+        plugin->setArpeggiatorGate(static_cast<float>(newGate));
+    notifyParametersChanged();
+}
+
+void ArpeggiatorViewModel::decrementGate() {
+    auto newGate = juce::jlimit(0.05, 1.0, getGate() - 0.05);
+    if (plugin != nullptr)
+        plugin->setArpeggiatorGate(static_cast<float>(newGate));
+    notifyParametersChanged();
+}
+
+bool ArpeggiatorViewModel::isEnabled() const {
+    return plugin != nullptr && plugin->isArpeggiatorEnabled();
+}
+
+void ArpeggiatorViewModel::toggleEnabled() {
+    if (plugin == nullptr)
+        return;
+
+    plugin->setArpeggiatorEnabled(!isEnabled());
+    notifyParametersChanged();
+}
+
+bool ArpeggiatorViewModel::isTempoSyncEnabled() const {
+    return plugin != nullptr && plugin->isArpeggiatorTempoSyncEnabled();
+}
+
+void ArpeggiatorViewModel::toggleTempoSync() {
+    if (plugin == nullptr)
+        return;
+
+    plugin->setArpeggiatorTempoSyncEnabled(!isTempoSyncEnabled());
+    notifyParametersChanged();
+}
+
+juce::String ArpeggiatorViewModel::getModeName() const {
+    switch (getMode()) {
+    case Mode::off:
+        return "Off";
+    case Mode::up:
+        return "Up";
+    case Mode::down:
+        return "Down";
+    case Mode::upDown:
+        return "Up-Down";
+    case Mode::random:
+        return "Random";
+    default:
+        return "Off";
+    }
+}
+
+void ArpeggiatorViewModel::notifyParametersChanged() {
+    listeners.call([](Listener &l) { l.parametersChanged(); });
+}
+
+} // namespace app_view_models

--- a/Source/Modules/app_view_models/Edit/Plugins/FourOsc/ArpeggiatorViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Plugins/FourOsc/ArpeggiatorViewModel.cpp
@@ -27,17 +27,23 @@ void ArpeggiatorViewModel::incrementMode() {
     auto next = static_cast<int>(getMode()) + 1;
     if (next > static_cast<int>(Mode::random))
         next = static_cast<int>(Mode::off);
-    if (plugin != nullptr)
-        plugin->setArpeggiatorMode(next);
-    notifyParametersChanged();
+    setMode(static_cast<Mode>(next));
 }
 
 void ArpeggiatorViewModel::decrementMode() {
     auto next = static_cast<int>(getMode()) - 1;
     if (next < static_cast<int>(Mode::off))
         next = static_cast<int>(Mode::random);
+    setMode(static_cast<Mode>(next));
+}
+
+void ArpeggiatorViewModel::setMode(Mode newMode) {
+    auto clamped =
+        juce::jlimit(static_cast<int>(Mode::off),
+                     static_cast<int>(Mode::random),
+                     static_cast<int>(newMode));
     if (plugin != nullptr)
-        plugin->setArpeggiatorMode(next);
+        plugin->setArpeggiatorMode(clamped);
     notifyParametersChanged();
 }
 
@@ -50,15 +56,20 @@ double ArpeggiatorViewModel::getRate() const {
 
 void ArpeggiatorViewModel::incrementRate() {
     auto newRate = juce::jlimit(1.0, 16.0, getRate() + 0.5);
-    if (plugin != nullptr)
-        plugin->setArpeggiatorRate(static_cast<float>(newRate));
-    notifyParametersChanged();
+    setRate(newRate);
 }
 
 void ArpeggiatorViewModel::decrementRate() {
     auto newRate = juce::jlimit(1.0, 16.0, getRate() - 0.5);
+    setRate(newRate);
+}
+
+void ArpeggiatorViewModel::setRate(double newRate) {
+    auto clamped = juce::jlimit(1.0, 16.0, newRate);
+    if (juce::approximatelyEqual(clamped, getRate()))
+        return;
     if (plugin != nullptr)
-        plugin->setArpeggiatorRate(static_cast<float>(newRate));
+        plugin->setArpeggiatorRate(static_cast<float>(clamped));
     notifyParametersChanged();
 }
 
@@ -71,15 +82,20 @@ int ArpeggiatorViewModel::getOctaves() const {
 
 void ArpeggiatorViewModel::incrementOctaves() {
     auto newValue = juce::jlimit(1, 4, getOctaves() + 1);
-    if (plugin != nullptr)
-        plugin->setArpeggiatorOctaves(newValue);
-    notifyParametersChanged();
+    setOctaves(newValue);
 }
 
 void ArpeggiatorViewModel::decrementOctaves() {
     auto newValue = juce::jlimit(1, 4, getOctaves() - 1);
+    setOctaves(newValue);
+}
+
+void ArpeggiatorViewModel::setOctaves(int newOctaves) {
+    auto clamped = juce::jlimit(1, 4, newOctaves);
+    if (clamped == getOctaves())
+        return;
     if (plugin != nullptr)
-        plugin->setArpeggiatorOctaves(newValue);
+        plugin->setArpeggiatorOctaves(clamped);
     notifyParametersChanged();
 }
 
@@ -92,15 +108,20 @@ double ArpeggiatorViewModel::getGate() const {
 
 void ArpeggiatorViewModel::incrementGate() {
     auto newGate = juce::jlimit(0.05, 1.0, getGate() + 0.05);
-    if (plugin != nullptr)
-        plugin->setArpeggiatorGate(static_cast<float>(newGate));
-    notifyParametersChanged();
+    setGate(newGate);
 }
 
 void ArpeggiatorViewModel::decrementGate() {
     auto newGate = juce::jlimit(0.05, 1.0, getGate() - 0.05);
+    setGate(newGate);
+}
+
+void ArpeggiatorViewModel::setGate(double newGate) {
+    auto clamped = juce::jlimit(0.05, 1.0, newGate);
+    if (juce::approximatelyEqual(clamped, getGate()))
+        return;
     if (plugin != nullptr)
-        plugin->setArpeggiatorGate(static_cast<float>(newGate));
+        plugin->setArpeggiatorGate(static_cast<float>(clamped));
     notifyParametersChanged();
 }
 

--- a/Source/Modules/app_view_models/Edit/Plugins/FourOsc/ArpeggiatorViewModel.h
+++ b/Source/Modules/app_view_models/Edit/Plugins/FourOsc/ArpeggiatorViewModel.h
@@ -1,0 +1,58 @@
+#pragma once
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+namespace internal_plugins {
+class CustomFourOscPlugin;
+}
+
+namespace app_view_models {
+
+class ArpeggiatorViewModel {
+  public:
+    enum class Mode { off = 0, up, down, upDown, random };
+
+    class Listener {
+      public:
+        virtual ~Listener() = default;
+        virtual void parametersChanged() {}
+    };
+
+    explicit ArpeggiatorViewModel(internal_plugins::CustomFourOscPlugin *p);
+
+    void addListener(Listener *l);
+    void removeListener(Listener *l);
+
+    Mode getMode() const;
+    void incrementMode();
+    void decrementMode();
+
+    double getRate() const;
+    void incrementRate();
+    void decrementRate();
+
+    int getOctaves() const;
+    void incrementOctaves();
+    void decrementOctaves();
+
+    double getGate() const;
+    void incrementGate();
+    void decrementGate();
+
+    bool isEnabled() const;
+    void toggleEnabled();
+    bool isTempoSyncEnabled() const;
+    void toggleTempoSync();
+
+    juce::String getModeName() const;
+
+  private:
+    internal_plugins::CustomFourOscPlugin *plugin;
+
+    juce::ListenerList<Listener> listeners;
+
+    void notifyParametersChanged();
+};
+
+} // namespace app_view_models

--- a/Source/Modules/app_view_models/Edit/Plugins/FourOsc/ArpeggiatorViewModel.h
+++ b/Source/Modules/app_view_models/Edit/Plugins/FourOsc/ArpeggiatorViewModel.h
@@ -27,18 +27,22 @@ class ArpeggiatorViewModel {
     Mode getMode() const;
     void incrementMode();
     void decrementMode();
+    void setMode(Mode newMode);
 
     double getRate() const;
     void incrementRate();
     void decrementRate();
+    void setRate(double newRate);
 
     int getOctaves() const;
     void incrementOctaves();
     void decrementOctaves();
+    void setOctaves(int newOctaves);
 
     double getGate() const;
     void incrementGate();
     void decrementGate();
+    void setGate(double newGate);
 
     bool isEnabled() const;
     void toggleEnabled();

--- a/Source/Modules/app_view_models/Edit/Plugins/PluginTree/PluginTreeGroup.cpp
+++ b/Source/Modules/app_view_models/Edit/Plugins/PluginTree/PluginTreeGroup.cpp
@@ -62,7 +62,7 @@ void addInternalPlugin(PluginTreeBase &item, int &num, bool synth = false,
 }
 
 void PluginTreeGroup::populateBuiltInInstruments(int &num) {
-    addInternalPlugin<tracktion::FourOscPlugin>(*this, num, true);
+    addInternalPlugin<internal_plugins::CustomFourOscPlugin>(*this, num, true);
     addInternalPlugin<tracktion::SamplerPlugin>(*this, num, true);
     addInternalPlugin<internal_plugins::DrumSamplerPlugin>(*this, num, true);
 }

--- a/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.cpp
@@ -4,7 +4,8 @@ namespace app_view_models {
 StepSequencerViewModel::StepSequencerViewModel(tracktion::AudioTrack::Ptr t)
     : track(t), state(track->state.getOrCreateChildWithName(
                     IDs::STEP_SEQUENCER_STATE, nullptr)),
-      editState(track->edit.state.getChildWithName(IDs::EDIT_VIEW_STATE)),
+      editState(track->edit.state.getOrCreateChildWithName(
+          IDs::EDIT_VIEW_STATE, nullptr)),
       stepSequence(state.getOrCreateChildWithName(
           app_models::IDs::STEP_SEQUENCE, nullptr)) {
     jassert(state.hasType(IDs::STEP_SEQUENCER_STATE));

--- a/Source/Modules/app_view_models/Edit/Settings/OutputListViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Settings/OutputListViewModel.cpp
@@ -12,14 +12,21 @@ OutputListViewModel::OutputListViewModel(tracktion::Edit &e,
     }
     itemListState.listSize = outputs.size();
 
+    auto savedOutput = ConfigurationHelpers::getSavedOutputDevice();
     auto currentDevice = deviceManager.getAudioDeviceSetup().outputDeviceName;
     int currentOutputIndex = 0;
-    if (currentDevice != "") {
-        currentOutputIndex =
-            outputs.indexOf(deviceManager.getCurrentAudioDevice()->getName());
+    if (savedOutput.isNotEmpty()) {
+        currentOutputIndex = outputs.indexOf(savedOutput);
         if (currentOutputIndex == -1) {
+            juce::Logger::writeToLog("Saved output device not available, using "
+                                     "current device instead: " +
+                                     savedOutput);
             currentOutputIndex = 0;
         }
+    } else if (currentDevice != "") {
+        currentOutputIndex = outputs.indexOf(currentDevice);
+        if (currentOutputIndex == -1)
+            currentOutputIndex = 0;
     } else {
         juce::Logger::writeToLog("current output device name is empty");
     }
@@ -34,6 +41,8 @@ OutputListViewModel::~OutputListViewModel() {
 juce::StringArray OutputListViewModel::getItemNames() { return outputs; }
 
 juce::String OutputListViewModel::getSelectedItem() {
+    if (outputs.isEmpty())
+        return {};
     return outputs[itemListState.getSelectedItemIndex()];
 }
 
@@ -44,6 +53,8 @@ void OutputListViewModel::updateOutput() {
     if (result != "") {
         juce::Logger::writeToLog("Error setting output device to " +
                                  getSelectedItem() + ": " + result);
+    } else {
+        ConfigurationHelpers::setSavedOutputDevice(getSelectedItem());
     }
 }
 

--- a/Source/Modules/app_view_models/app_view_models.cpp
+++ b/Source/Modules/app_view_models/app_view_models.cpp
@@ -39,7 +39,7 @@
 #include "Edit/Plugins/FourOsc/OscillatorViewModel.cpp"
 #include "Edit/Plugins/FourOsc/ADSRViewModel.cpp"
 #include "Edit/Plugins/FourOsc/FilterViewModel.cpp"
-
+#include "Edit/Plugins/FourOsc/ArpeggiatorViewModel.cpp"
 // Modifiers
 #include "Edit/Modifiers/ModifierList.cpp"
 #include "Edit/Modifiers/TrackModifiersListViewModel.cpp"

--- a/Source/Modules/app_view_models/app_view_models.h
+++ b/Source/Modules/app_view_models/app_view_models.h
@@ -49,6 +49,7 @@ namespace app_view_models {
     class OscillatorViewModel;
     class ADSRViewModel;
     class FilterViewModel;
+    class ArpeggiatorViewModel;
     class MixerViewModel;
     class MixerTrackViewModel;
     class SettingsListViewModel;
@@ -112,6 +113,7 @@ namespace app_view_models {
 #include "Edit/Plugins/FourOsc/OscillatorViewModel.h"
 #include "Edit/Plugins/FourOsc/ADSRViewModel.h"
 #include "Edit/Plugins/FourOsc/FilterViewModel.h"
+#include "Edit/Plugins/FourOsc/ArpeggiatorViewModel.h"
 
 // Modifiers
 #include "Edit/Modifiers/TrackModifiersListViewModel.h"

--- a/Source/Modules/internal_plugins/CustomFourOscPlugin/CustomFourOscPlugin.cpp
+++ b/Source/Modules/internal_plugins/CustomFourOscPlugin/CustomFourOscPlugin.cpp
@@ -1,0 +1,313 @@
+#include "CustomFourOscPlugin.h"
+
+namespace internal_plugins {
+
+const char *CustomFourOscPlugin::xmlTypeName = "custom4osc";
+
+CustomFourOscPlugin::ArpParams::ArpParams(CustomFourOscPlugin &plugin) {
+    auto um = plugin.getUndoManager();
+
+    using namespace CustomFourOscIDs;
+
+    enabledValue.referTo(plugin.state, arpEnabled, um, false);
+    modeValue.referTo(plugin.state, arpMode, um, 0);
+    syncValue.referTo(plugin.state, arpSync, um, true);
+    rateValue.referTo(plugin.state, arpRate, um, 4.0f);
+    gateValue.referTo(plugin.state, arpGate, um, 0.5f);
+    octavesValue.referTo(plugin.state, arpOctaves, um, 1);
+
+    rate = plugin.addArpParam("arpRate", TRANS("Arp Rate"), {1.0f, 16.0f});
+    gate = plugin.addArpParam("arpGate", TRANS("Arp Gate"), {0.05f, 1.0f});
+}
+
+void CustomFourOscPlugin::ArpParams::attach() {
+    rate->attachToCurrentValue(rateValue);
+    gate->attachToCurrentValue(gateValue);
+}
+
+void CustomFourOscPlugin::ArpParams::detach() {
+    rate->detachFromCurrentValue();
+    gate->detachFromCurrentValue();
+}
+
+CustomFourOscPlugin::CustomFourOscPlugin(tracktion::PluginCreationInfo info)
+    : tracktion::FourOscPlugin(info) {
+    // Initialize arpeggiator
+    arpParams = std::make_unique<ArpParams>(*this);
+
+    if (arpParams)
+        arpParams->attach();
+}
+
+CustomFourOscPlugin::~CustomFourOscPlugin() {
+    notifyListenersOfDeletion();
+
+    if (arpParams)
+        arpParams->detach();
+}
+
+void CustomFourOscPlugin::applyToBuffer(
+    const tracktion::PluginRenderContext &fc) {
+    if (arpParams != nullptr && fc.bufferForMidiMessages != nullptr) {
+        arpTempoPosition.set(fc.editTime.getStart());
+        arpCurrentTempo = float(arpTempoPosition.getTempo());
+        processArpeggiator(*fc.bufferForMidiMessages, fc.bufferNumSamples,
+                           fc.bufferStartSample);
+    }
+
+    tracktion::FourOscPlugin::applyToBuffer(fc);
+}
+
+void CustomFourOscPlugin::restorePluginStateFromValueTree(
+    const juce::ValueTree &v) {
+    // Call base class first
+    tracktion::FourOscPlugin::restorePluginStateFromValueTree(v);
+
+    // Restore arpeggiator state
+    if (arpParams)
+        arpParams->restorePluginStateFromValueTree(v);
+}
+
+void CustomFourOscPlugin::addNoteToArpeggiator(int noteNumber) {
+    arpNoteBuffer.addIfNotAlreadyThere(noteNumber);
+}
+
+void CustomFourOscPlugin::removeNoteFromArpeggiator(int noteNumber) {
+    arpNoteBuffer.removeAllInstancesOf(noteNumber);
+}
+
+void CustomFourOscPlugin::clearArpeggiatorNotes() { arpNoteBuffer.clear(); }
+
+bool CustomFourOscPlugin::isArpeggiatorEnabled() const {
+    return arpParams != nullptr && arpParams->enabledValue.get();
+}
+
+void CustomFourOscPlugin::setArpeggiatorEnabled(bool shouldEnable) {
+    if (arpParams != nullptr)
+        arpParams->enabledValue = shouldEnable;
+}
+
+bool CustomFourOscPlugin::isArpeggiatorTempoSyncEnabled() const {
+    return arpParams != nullptr && arpParams->syncValue.get();
+}
+
+void CustomFourOscPlugin::setArpeggiatorTempoSyncEnabled(bool shouldSync) {
+    if (arpParams != nullptr)
+        arpParams->syncValue = shouldSync;
+}
+
+int CustomFourOscPlugin::getArpeggiatorMode() const {
+    if (arpParams == nullptr)
+        return 0;
+
+    return juce::jlimit(0, 4, arpParams->modeValue.get());
+}
+
+void CustomFourOscPlugin::setArpeggiatorMode(int modeIndex) {
+    if (arpParams == nullptr)
+        return;
+
+    arpParams->modeValue = juce::jlimit(0, 4, modeIndex);
+}
+
+float CustomFourOscPlugin::getArpeggiatorRate() const {
+    if (arpParams == nullptr)
+        return 4.0f;
+
+    return arpParams->rateValue.get();
+}
+
+void CustomFourOscPlugin::setArpeggiatorRate(float newRate) {
+    if (arpParams == nullptr)
+        return;
+
+    arpParams->rateValue = juce::jlimit(1.0f, 16.0f, newRate);
+}
+
+int CustomFourOscPlugin::getArpeggiatorOctaves() const {
+    if (arpParams == nullptr)
+        return 1;
+
+    return juce::jlimit(1, 4, arpParams->octavesValue.get());
+}
+
+void CustomFourOscPlugin::setArpeggiatorOctaves(int newOctaves) {
+    if (arpParams == nullptr)
+        return;
+
+    arpParams->octavesValue = juce::jlimit(1, 4, newOctaves);
+}
+
+float CustomFourOscPlugin::getArpeggiatorGate() const {
+    if (arpParams == nullptr)
+        return 0.5f;
+
+    return arpParams->gateValue.get();
+}
+
+void CustomFourOscPlugin::setArpeggiatorGate(float newGate) {
+    if (arpParams == nullptr)
+        return;
+
+    arpParams->gateValue = juce::jlimit(0.05f, 1.0f, newGate);
+}
+
+tracktion::AutomatableParameter::Ptr
+CustomFourOscPlugin::addArpParam(const juce::String &paramID,
+                                 const juce::String &name,
+                                 juce::NormalisableRange<float> valueRange) {
+    auto *newParam =
+        new tracktion::AutomatableParameter(paramID, name, *this, valueRange);
+    addAutomatableParameter(*newParam);
+    return newParam;
+}
+
+void CustomFourOscPlugin::processArpeggiator(tracktion::MidiMessageArray &midi,
+                                             int numSamples,
+                                             int bufferStartSample) {
+    if (!arpParams || !arpParams->enabledValue.get())
+        return;
+
+    const double sr = this->tracktion::Plugin::sampleRate;
+
+    if (numSamples <= 0 || sr <= 0.0)
+        return;
+
+    tracktion::MidiMessageArray processedMidi;
+    processedMidi.isAllNotesOff = midi.isAllNotesOff;
+
+    const int bufferEndSample = bufferStartSample + numSamples;
+
+    for (const auto &metadata : midi) {
+        const double eventTime = metadata.getTimeStamp();
+
+        if (eventTime < bufferStartSample || eventTime >= bufferEndSample) {
+            processedMidi.addMidiMessage(metadata, eventTime,
+                                         metadata.mpeSourceID);
+            continue;
+        }
+
+        const juce::MidiMessage &msg = metadata;
+
+        if (msg.isNoteOn()) {
+            if (arpNoteBuffer.size() < 128)
+                arpNoteBuffer.addIfNotAlreadyThere(msg.getNoteNumber());
+        } else if (msg.isNoteOff()) {
+            arpNoteBuffer.removeAllInstancesOf(msg.getNoteNumber());
+        } else {
+            processedMidi.addMidiMessage(msg, eventTime, metadata.mpeSourceID);
+        }
+    }
+
+    if (arpNoteBuffer.isEmpty()) {
+        if (arpNoteIsOn && arpCurrentNoteNumber >= 0) {
+            processedMidi.addMidiMessage(
+                juce::MidiMessage::noteOff(1, arpCurrentNoteNumber),
+                bufferStartSample, arpSourceID);
+            arpNoteIsOn = false;
+        }
+
+        midi.swapWith(processedMidi);
+        return;
+    }
+
+    const bool syncToTempo = arpParams->syncValue.get();
+    float rate = arpParams->rateValue.get();
+
+    if (rate <= 0.001f)
+        rate = 4.0f;
+
+    int samplesPerStep = 0;
+
+    if (syncToTempo) {
+        const float beatsPerStep = 1.0f / rate;
+        float tempo = arpCurrentTempo;
+        if (tempo <= 0.001f)
+            tempo = 120.0f;
+
+        samplesPerStep = int((60.0f / tempo) * beatsPerStep * sr);
+    } else {
+        samplesPerStep = int((1.0f / rate) * sr);
+    }
+
+    if (samplesPerStep <= 0 || samplesPerStep > int(sr) * 10)
+        samplesPerStep = int(sr / 4.0);
+
+    samplesPerStep = std::max(1, samplesPerStep);
+
+    float gate = juce::jlimit(0.05f, 1.0f, arpParams->gateValue.get());
+    int noteOnDuration =
+        juce::jlimit(1, samplesPerStep, int(std::floor(samplesPerStep * gate)));
+
+    int mode = arpParams->modeValue.get();
+    juce::Array<int> sortedNotes = arpNoteBuffer;
+
+    if (mode == 0) {
+        sortedNotes.sort();
+    } else if (mode == 1) {
+        sortedNotes.sort();
+        for (int i = 0; i < sortedNotes.size() / 2; ++i)
+            std::swap(sortedNotes.getReference(i),
+                      sortedNotes.getReference(sortedNotes.size() - 1 - i));
+    } else if (mode == 2) {
+        sortedNotes.sort();
+        juce::Array<int> upDown;
+        for (auto note : sortedNotes)
+            upDown.add(note);
+        for (int i = sortedNotes.size() - 2; i > 0; --i)
+            upDown.add(sortedNotes[i]);
+        sortedNotes = upDown;
+    } else if (mode == 3) {
+        sortedNotes.sort();
+        juce::Random random;
+        for (int i = 0; i < sortedNotes.size(); ++i) {
+            const int j = random.nextInt(sortedNotes.size());
+            std::swap(sortedNotes.getReference(i), sortedNotes.getReference(j));
+        }
+    }
+
+    for (int sample = 0; sample < numSamples; ++sample) {
+        const int absoluteSample = bufferStartSample + sample;
+
+        if (arpNoteIsOn && arpSampleCounter >= noteOnDuration) {
+            processedMidi.addMidiMessage(
+                juce::MidiMessage::noteOff(1, arpCurrentNoteNumber),
+                absoluteSample, arpSourceID);
+            arpNoteIsOn = false;
+        }
+
+        if (arpSampleCounter >= samplesPerStep) {
+            arpSampleCounter = 0;
+
+            if (arpNoteIsOn && arpCurrentNoteNumber >= 0) {
+                processedMidi.addMidiMessage(
+                    juce::MidiMessage::noteOff(1, arpCurrentNoteNumber),
+                    absoluteSample, arpSourceID);
+                arpNoteIsOn = false;
+            }
+
+            if (!sortedNotes.isEmpty()) {
+                arpCurrentStep = (arpCurrentStep + 1) % sortedNotes.size();
+                int baseNote = sortedNotes[arpCurrentStep];
+
+                int octaves = juce::jlimit(1, 4, arpParams->octavesValue.get());
+                int octaveOffset =
+                    (arpCurrentStep / sortedNotes.size()) % octaves;
+
+                arpCurrentNoteNumber =
+                    juce::jlimit(0, 127, baseNote + octaveOffset * 12);
+
+                processedMidi.addMidiMessage(
+                    juce::MidiMessage::noteOn(1, arpCurrentNoteNumber, 1.0f),
+                    absoluteSample, arpSourceID);
+                arpNoteIsOn = true;
+            }
+        }
+
+        arpSampleCounter++;
+    }
+
+    midi.swapWith(processedMidi);
+}
+
+} // namespace internal_plugins

--- a/Source/Modules/internal_plugins/CustomFourOscPlugin/CustomFourOscPlugin.h
+++ b/Source/Modules/internal_plugins/CustomFourOscPlugin/CustomFourOscPlugin.h
@@ -17,10 +17,10 @@ class CustomFourOscPlugin : public tracktion::FourOscPlugin {
     explicit CustomFourOscPlugin(tracktion::PluginCreationInfo info);
     ~CustomFourOscPlugin() override;
 
-    static const char *getPluginName() { return NEEDS_TRANS("Custom4OSC"); }
+    static const char *getPluginName() { return NEEDS_TRANS("4OSC"); }
     static const char *xmlTypeName;
 
-    juce::String getName() const override { return TRANS("Custom 4OSC"); }
+    juce::String getName() const override { return TRANS("4OSC"); }
     juce::String getPluginType() override { return xmlTypeName; }
     juce::String getShortName(int) override { return "C4OSC"; }
     juce::String getSelectableDescription() override {
@@ -81,6 +81,8 @@ class CustomFourOscPlugin : public tracktion::FourOscPlugin {
 
     void processArpeggiator(tracktion::MidiMessageArray &midi, int numSamples,
                             int bufferStartSample);
+    void stopArpeggiator(tracktion::MidiMessageArray *midi,
+                         int bufferStartSample);
 
     // Arpeggiator state
     juce::Array<int> arpNoteBuffer;
@@ -88,6 +90,7 @@ class CustomFourOscPlugin : public tracktion::FourOscPlugin {
     int arpSampleCounter = 0;
     int arpCurrentNoteNumber = -1;
     bool arpNoteIsOn = false;
+    bool wasTransportPlaying = false;
     tracktion::MPESourceID arpSourceID{tracktion::createUniqueMPESourceID()};
     tracktion::tempo::Sequence::Position arpTempoPosition{
         tracktion::createPosition(edit.tempoSequence)};

--- a/Source/Modules/internal_plugins/CustomFourOscPlugin/CustomFourOscPlugin.h
+++ b/Source/Modules/internal_plugins/CustomFourOscPlugin/CustomFourOscPlugin.h
@@ -1,0 +1,100 @@
+#pragma once
+#include <tracktion_engine/tracktion_engine.h>
+
+namespace internal_plugins {
+
+namespace CustomFourOscIDs {
+static const juce::Identifier arpEnabled{"customArpEnabled"};
+static const juce::Identifier arpMode{"customArpMode"};
+static const juce::Identifier arpSync{"customArpSync"};
+static const juce::Identifier arpRate{"customArpRate"};
+static const juce::Identifier arpGate{"customArpGate"};
+static const juce::Identifier arpOctaves{"customArpOctaves"};
+} // namespace CustomFourOscIDs
+
+class CustomFourOscPlugin : public tracktion::FourOscPlugin {
+  public:
+    explicit CustomFourOscPlugin(tracktion::PluginCreationInfo info);
+    ~CustomFourOscPlugin() override;
+
+    static const char *getPluginName() { return NEEDS_TRANS("Custom4OSC"); }
+    static const char *xmlTypeName;
+
+    juce::String getName() const override { return TRANS("Custom 4OSC"); }
+    juce::String getPluginType() override { return xmlTypeName; }
+    juce::String getShortName(int) override { return "C4OSC"; }
+    juce::String getSelectableDescription() override {
+        return TRANS("4OSC with Custom Arpeggiator");
+    }
+
+    // Override to intercept MIDI processing for arpeggiator
+    void applyToBuffer(const tracktion::PluginRenderContext &fc) override;
+    void restorePluginStateFromValueTree(const juce::ValueTree &v) override;
+
+    // Arpeggiator public interface
+    void addNoteToArpeggiator(int noteNumber);
+    void removeNoteFromArpeggiator(int noteNumber);
+    void clearArpeggiatorNotes();
+    juce::Array<int> getArpeggiatorNotes() const { return arpNoteBuffer; }
+    bool isArpeggiatorEnabled() const;
+    void setArpeggiatorEnabled(bool shouldEnable);
+    bool isArpeggiatorTempoSyncEnabled() const;
+    void setArpeggiatorTempoSyncEnabled(bool shouldSync);
+    int getArpeggiatorMode() const;
+    void setArpeggiatorMode(int modeIndex);
+    float getArpeggiatorRate() const;
+    void setArpeggiatorRate(float newRate);
+    int getArpeggiatorOctaves() const;
+    void setArpeggiatorOctaves(int newOctaves);
+    float getArpeggiatorGate() const;
+    void setArpeggiatorGate(float newGate);
+
+    // Arpeggiator parameters structure
+    struct ArpParams {
+        ArpParams(CustomFourOscPlugin &plugin);
+        void attach();
+        void detach();
+
+        juce::CachedValue<bool> enabledValue;
+        juce::CachedValue<int> modeValue;
+        juce::CachedValue<bool> syncValue;
+        juce::CachedValue<float> rateValue, gateValue;
+        juce::CachedValue<int> octavesValue;
+
+        tracktion::AutomatableParameter::Ptr rate, gate;
+
+        void restorePluginStateFromValueTree(const juce::ValueTree &v) {
+            tracktion::copyPropertiesToCachedValues(v, enabledValue, modeValue,
+                                                    syncValue, rateValue,
+                                                    gateValue, octavesValue);
+        }
+    };
+
+    std::unique_ptr<ArpParams> arpParams;
+
+  private:
+    friend struct ArpParams;
+
+    tracktion::AutomatableParameter::Ptr
+    addArpParam(const juce::String &paramID, const juce::String &name,
+                juce::NormalisableRange<float> valueRange);
+
+    void processArpeggiator(tracktion::MidiMessageArray &midi, int numSamples,
+                            int bufferStartSample);
+
+    // Arpeggiator state
+    juce::Array<int> arpNoteBuffer;
+    int arpCurrentStep = 0;
+    int arpSampleCounter = 0;
+    int arpCurrentNoteNumber = -1;
+    bool arpNoteIsOn = false;
+    tracktion::MPESourceID arpSourceID{tracktion::createUniqueMPESourceID()};
+    tracktion::tempo::Sequence::Position arpTempoPosition{
+        tracktion::createPosition(edit.tempoSequence)};
+
+    float arpCurrentTempo = 120.0f;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(CustomFourOscPlugin)
+};
+
+} // namespace internal_plugins

--- a/Source/Modules/internal_plugins/internal_plugins.cpp
+++ b/Source/Modules/internal_plugins/internal_plugins.cpp
@@ -1,4 +1,4 @@
 // clang-format off
 #include "internal_plugins.h"
-
 #include "DrumSamplerPlugin/DrumSamplerPlugin.cpp"
+#include "CustomFourOscPlugin/CustomFourOscPlugin.cpp"

--- a/Source/Modules/internal_plugins/internal_plugins.h
+++ b/Source/Modules/internal_plugins/internal_plugins.h
@@ -16,7 +16,7 @@
 namespace internal_plugins {
 
     class DrumSamplerPlugin;
-
+    class CustomFourOscPlugin;
 }
 
 #include <juce_data_structures/juce_data_structures.h>

--- a/Source/Modules/internal_plugins/internal_plugins.h
+++ b/Source/Modules/internal_plugins/internal_plugins.h
@@ -27,6 +27,6 @@ namespace internal_plugins {
 #include <functional>
 
 #include "DrumSamplerPlugin/DrumSamplerPlugin.h"
-
+#include "CustomFourOscPlugin/CustomFourOscPlugin.h"
 
 

--- a/Source/Views/Edit/Plugins/FourOsc/ADSRView.h
+++ b/Source/Views/Edit/Plugins/FourOsc/ADSRView.h
@@ -31,8 +31,11 @@ class ADSRView : public juce::Component,
     void encoder4Decreased() override;
 
     void parametersChanged() override;
+    void visibilityChanged() override;
 
   private:
+    void attachSliderCallbacks();
+
     app_view_models::ADSRViewModel viewModel;
     app_services::MidiCommandManager &midiCommandManager;
     juce::Label titleLabel;
@@ -42,6 +45,7 @@ class ADSRView : public juce::Component,
 
     juce::Grid grid;
     void gridSetup();
+    bool sliderUpdateInProgress = false;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ADSRView)
 };

--- a/Source/Views/Edit/Plugins/FourOsc/ArpeggiatorView.cpp
+++ b/Source/Views/Edit/Plugins/FourOsc/ArpeggiatorView.cpp
@@ -1,0 +1,160 @@
+#include "ArpeggiatorView.h"
+#include <internal_plugins/CustomFourOscPlugin/CustomFourOscPlugin.h>
+
+ArpeggiatorView::ArpeggiatorView(tracktion::FourOscPlugin *p,
+                                 app_services::MidiCommandManager &mcm)
+    : viewModel(dynamic_cast<internal_plugins::CustomFourOscPlugin *>(p)),
+      midiCommandManager(mcm), knobs(mcm, 4) {
+    titleLabel.setFont(juce::Font(juce::Font::getDefaultMonospacedFontName(),
+                                  getHeight() * 0.1f, juce::Font::plain));
+    titleLabel.setText("4OSC: Arpeggiator", juce::dontSendNotification);
+    titleLabel.setJustificationType(juce::Justification::centred);
+    addAndMakeVisible(titleLabel);
+
+    statusLabel.setJustificationType(juce::Justification::centred);
+    statusLabel.setColour(juce::Label::textColourId, lookAndFeel.textColour);
+    addAndMakeVisible(statusLabel);
+
+    tempoSyncButton.setButtonText("Tempo Sync");
+    tempoSyncButton.onClick = [this]() { viewModel.toggleTempoSync(); };
+    tempoSyncButton.setColour(juce::ToggleButton::textColourId,
+                              lookAndFeel.textColour);
+    addAndMakeVisible(tempoSyncButton);
+
+    knobs.getKnob(0)->getLabel().setText("Mode", juce::dontSendNotification);
+    knobs.getKnob(0)->getSlider().setRange(0, 4, 1);
+
+    knobs.getKnob(1)->getLabel().setText("Rate (Hz)",
+                                         juce::dontSendNotification);
+    knobs.getKnob(1)->getSlider().setRange(1.0, 16.0, 0.5);
+    knobs.getKnob(1)->getSlider().setNumDecimalPlacesToDisplay(1);
+
+    knobs.getKnob(2)->getLabel().setText("Octaves",
+                                         juce::dontSendNotification);
+    knobs.getKnob(2)->getSlider().setRange(1, 4, 1);
+
+    knobs.getKnob(3)->getLabel().setText("Gate",
+                                         juce::dontSendNotification);
+    knobs.getKnob(3)->getSlider().setRange(0.05, 1.0, 0.05);
+    knobs.getKnob(3)->getSlider().setNumDecimalPlacesToDisplay(2);
+
+    addAndMakeVisible(knobs);
+
+    midiCommandManager.addListener(this);
+    viewModel.addListener(this);
+    parametersChanged();
+}
+
+ArpeggiatorView::~ArpeggiatorView() {
+    midiCommandManager.removeListener(this);
+    viewModel.removeListener(this);
+}
+
+void ArpeggiatorView::paint(juce::Graphics &g) {
+    g.fillAll(
+        getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
+}
+
+void ArpeggiatorView::resized() {
+    titleLabel.setFont(juce::Font(juce::Font::getDefaultMonospacedFontName(),
+                                  getHeight() * 0.1f, juce::Font::plain));
+    titleLabel.setBounds(0, getHeight() * .05, getWidth(), getHeight() * .1);
+
+    int knobWidth = getWidth() / 8;
+    int knobHeight = getHeight() / 3;
+    int knobSpacing = knobWidth;
+    int width = (4 * knobWidth) + (3 * knobSpacing);
+    int height = knobHeight;
+    int startX = (getWidth() / 2) - (width / 2);
+    int startY = (getHeight() / 2) - (knobHeight / 2);
+    juce::Rectangle<int> bounds(startX, startY, width, height);
+    knobs.setGridSpacing(knobSpacing);
+    knobs.setBounds(bounds);
+
+    int buttonWidth = juce::jmin(getWidth() / 3, 200);
+    int buttonHeight =
+        juce::jmax(24, juce::roundToInt(getHeight() * 0.08f));
+    int buttonY = juce::roundToInt(getHeight() * 0.72f);
+    tempoSyncButton.setBounds((getWidth() - buttonWidth) / 2, buttonY,
+                              buttonWidth, buttonHeight);
+
+    statusLabel.setBounds(0, getHeight() * .82, getWidth(), getHeight() * .1);
+}
+
+void ArpeggiatorView::encoder1Increased() {
+    if (isShowing() && midiCommandManager.getFocusedComponent() == this)
+        viewModel.incrementMode();
+}
+
+void ArpeggiatorView::encoder1Decreased() {
+    if (isShowing() && midiCommandManager.getFocusedComponent() == this)
+        viewModel.decrementMode();
+}
+
+void ArpeggiatorView::encoder1ButtonReleased() {
+    if (isShowing() && midiCommandManager.getFocusedComponent() == this) {
+        viewModel.toggleTempoSync();
+    }
+}
+
+void ArpeggiatorView::encoder2Increased() {
+    if (isShowing() && midiCommandManager.getFocusedComponent() == this)
+        viewModel.incrementRate();
+}
+
+void ArpeggiatorView::encoder2Decreased() {
+    if (isShowing() && midiCommandManager.getFocusedComponent() == this)
+        viewModel.decrementRate();
+}
+
+void ArpeggiatorView::encoder3Increased() {
+    if (isShowing() && midiCommandManager.getFocusedComponent() == this) {
+        viewModel.incrementOctaves();
+    }
+}
+
+void ArpeggiatorView::encoder3Decreased() {
+    if (isShowing() && midiCommandManager.getFocusedComponent() == this) {
+        viewModel.decrementOctaves();
+    }
+}
+
+void ArpeggiatorView::encoder4Increased() {
+    if (isShowing() && midiCommandManager.getFocusedComponent() == this) {
+        viewModel.incrementGate();
+    }
+}
+
+void ArpeggiatorView::encoder4Decreased() {
+    if (isShowing() && midiCommandManager.getFocusedComponent() == this) {
+        viewModel.decrementGate();
+    }
+}
+
+void ArpeggiatorView::controlButtonPressed() { viewModel.toggleEnabled(); }
+
+void ArpeggiatorView::parametersChanged() {
+    knobs.getKnob(0)->getSlider().setValue(static_cast<int>(viewModel.getMode()),
+                                           juce::dontSendNotification);
+    knobs.getKnob(1)->getSlider().setValue(viewModel.getRate(),
+                                           juce::dontSendNotification);
+    knobs.getKnob(2)->getSlider().setValue(viewModel.getOctaves(),
+                                           juce::dontSendNotification);
+    knobs.getKnob(3)->getSlider().setValue(viewModel.getGate(),
+                                           juce::dontSendNotification);
+    tempoSyncButton.setToggleState(viewModel.isTempoSyncEnabled(),
+                                   juce::dontSendNotification);
+    updateStatusLabel();
+}
+
+void ArpeggiatorView::updateStatusLabel() {
+    juce::String status = viewModel.isEnabled() ? "ON" : "OFF";
+    bool tempoSync = viewModel.isTempoSyncEnabled();
+    juce::String rateValue = juce::String(viewModel.getRate(), 1);
+    juce::String rateSuffix = tempoSync ? " steps/beat" : " Hz";
+    juce::String syncStatus = tempoSync ? "Tempo" : "Free";
+    statusLabel.setText(
+        "Status: " + status + " | Mode: " + viewModel.getModeName() +
+            " | Rate: " + rateValue + rateSuffix + " | Sync: " + syncStatus,
+        juce::dontSendNotification);
+}

--- a/Source/Views/Edit/Plugins/FourOsc/ArpeggiatorView.h
+++ b/Source/Views/Edit/Plugins/FourOsc/ArpeggiatorView.h
@@ -1,0 +1,43 @@
+#pragma once
+#include "AppLookAndFeel.h"
+#include "Knobs.h"
+#include <app_services/app_services.h>
+#include <app_view_models/app_view_models.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <tracktion_engine/tracktion_engine.h>
+
+class ArpeggiatorView : public juce::Component,
+                        public app_services::MidiCommandManager::Listener,
+                        public app_view_models::ArpeggiatorViewModel::Listener {
+  public:
+    ArpeggiatorView(tracktion::FourOscPlugin *p,
+                    app_services::MidiCommandManager &mcm);
+    ~ArpeggiatorView() override;
+
+    void paint(juce::Graphics &g) override;
+    void resized() override;
+
+    void encoder1Increased() override;
+    void encoder1Decreased() override;
+    void encoder1ButtonReleased() override;
+    void encoder2Increased() override;
+    void encoder2Decreased() override;
+    void encoder3Increased() override;
+    void encoder3Decreased() override;
+    void encoder4Increased() override;
+    void encoder4Decreased() override;
+    void controlButtonPressed() override;
+
+    void parametersChanged() override;
+
+  private:
+    app_view_models::ArpeggiatorViewModel viewModel;
+    app_services::MidiCommandManager &midiCommandManager;
+    AppLookAndFeel lookAndFeel;
+    Knobs knobs;
+    juce::Label titleLabel;
+    juce::Label statusLabel;
+    juce::ToggleButton tempoSyncButton;
+
+    void updateStatusLabel();
+};

--- a/Source/Views/Edit/Plugins/FourOsc/ArpeggiatorView.h
+++ b/Source/Views/Edit/Plugins/FourOsc/ArpeggiatorView.h
@@ -29,6 +29,7 @@ class ArpeggiatorView : public juce::Component,
     void controlButtonPressed() override;
 
     void parametersChanged() override;
+    void visibilityChanged() override;
 
   private:
     app_view_models::ArpeggiatorViewModel viewModel;
@@ -38,6 +39,8 @@ class ArpeggiatorView : public juce::Component,
     juce::Label titleLabel;
     juce::Label statusLabel;
     juce::ToggleButton tempoSyncButton;
+    bool sliderUpdateInProgress = false;
 
     void updateStatusLabel();
+    void attachSliderCallbacks();
 };

--- a/Source/Views/Edit/Plugins/FourOsc/FilterADSRView.cpp
+++ b/Source/Views/Edit/Plugins/FourOsc/FilterADSRView.cpp
@@ -1,4 +1,6 @@
 #include "FilterADSRView.h"
+#include <cmath>
+#include <functional>
 
 FilterADSRView::FilterADSRView(tracktion::FourOscPlugin *p,
                                app_services::MidiCommandManager &mcm)
@@ -73,6 +75,7 @@ FilterADSRView::FilterADSRView(tracktion::FourOscPlugin *p,
 
     midiCommandManager.addListener(this);
     viewModel.addListener(this);
+    attachSliderCallbacks();
 }
 
 FilterADSRView::~FilterADSRView() {
@@ -161,6 +164,7 @@ void FilterADSRView::encoder4Decreased() {
 }
 
 void FilterADSRView::parametersChanged() {
+    const juce::ScopedValueSetter<bool> updating(sliderUpdateInProgress, true);
     knobs[0]->getSlider().setValue(viewModel.getAttack(),
                                    juce::dontSendNotification);
     knobs[1]->getSlider().setValue(viewModel.getDecay(),
@@ -175,4 +179,40 @@ void FilterADSRView::parametersChanged() {
     adsrPlot.sustainValue = viewModel.getSustain();
     adsrPlot.releaseValue = viewModel.getRelease();
     adsrPlot.repaint();
+}
+
+void FilterADSRView::attachSliderCallbacks() {
+    auto attach = [this](int index,
+                         void (app_view_models::FilterViewModel::*inc)(),
+                         void (app_view_models::FilterViewModel::*dec)(),
+                         std::function<double()> getter) {
+        auto &slider = knobs[index]->getSlider();
+        slider.onValueChange = [this, inc, dec, getter, &slider]() {
+            if (sliderUpdateInProgress)
+                return;
+            double target = slider.getValue();
+            double current = getter();
+            int iterations = 0;
+            while (std::abs(target - current) > 0.005 && iterations++ < 200) {
+                if (target > current)
+                    (viewModel.*inc)();
+                else
+                    (viewModel.*dec)();
+                current = getter();
+            }
+        };
+    };
+
+    attach(0, &app_view_models::FilterViewModel::incrementAttack,
+           &app_view_models::FilterViewModel::decrementAttack,
+           [this]() { return viewModel.getAttack(); });
+    attach(1, &app_view_models::FilterViewModel::incrementDecay,
+           &app_view_models::FilterViewModel::decrementDecay,
+           [this]() { return viewModel.getDecay(); });
+    attach(2, &app_view_models::FilterViewModel::incrementSustain,
+           &app_view_models::FilterViewModel::decrementSustain,
+           [this]() { return viewModel.getSustain(); });
+    attach(3, &app_view_models::FilterViewModel::incrementRelease,
+           &app_view_models::FilterViewModel::decrementRelease,
+           [this]() { return viewModel.getRelease(); });
 }

--- a/Source/Views/Edit/Plugins/FourOsc/FilterADSRView.h
+++ b/Source/Views/Edit/Plugins/FourOsc/FilterADSRView.h
@@ -33,6 +33,8 @@ class FilterADSRView : public juce::Component,
     void parametersChanged() override;
 
   private:
+    void attachSliderCallbacks();
+
     app_view_models::FilterViewModel viewModel;
     app_services::MidiCommandManager &midiCommandManager;
     juce::Label titleLabel;
@@ -42,6 +44,7 @@ class FilterADSRView : public juce::Component,
 
     juce::Grid grid;
     void gridSetup();
+    bool sliderUpdateInProgress = false;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FilterADSRView)
 };

--- a/Source/Views/Edit/Plugins/FourOsc/FilterView.h
+++ b/Source/Views/Edit/Plugins/FourOsc/FilterView.h
@@ -34,14 +34,18 @@ class FilterView : public juce::Component,
     void controlButtonReleased() override;
 
     void parametersChanged() override;
+    void visibilityChanged() override;
 
   private:
+    void attachSliderCallbacks();
+
     app_view_models::FilterViewModel viewModel;
     app_services::MidiCommandManager &midiCommandManager;
     juce::Label titleLabel;
     Knobs knobs;
     FilterADSRView filterAdsrView;
     AppLookAndFeel appLookAndFeel;
+    bool sliderUpdateInProgress = false;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FilterView)
 };

--- a/Source/Views/Edit/Plugins/FourOsc/FourOscView.cpp
+++ b/Source/Views/Edit/Plugins/FourOsc/FourOscView.cpp
@@ -20,6 +20,8 @@ FourOscView::FourOscView(tracktion::FourOscPlugin *p,
            new ADSRView(plugin, midiCommandManager), true);
     addTab(filterTabName, juce::Colours::transparentBlack,
            new FilterView(plugin, midiCommandManager), true);
+    addTab(arpTabName, juce::Colours::transparentBlack,
+           new ArpeggiatorView(plugin, midiCommandManager), true);
     midiCommandManager.addListener(this);
 
     // hide tab bar

--- a/Source/Views/Edit/Plugins/FourOsc/FourOscView.cpp
+++ b/Source/Views/Edit/Plugins/FourOsc/FourOscView.cpp
@@ -30,6 +30,7 @@ FourOscView::FourOscView(tracktion::FourOscPlugin *p,
     juce::StringArray tabNames = getTabNames();
     int osc1Index = tabNames.indexOf(osc1TabName);
     setCurrentTabIndex(osc1Index);
+    focusCurrentTab();
 
     pageLabel.setFont(juce::Font(juce::Font::getDefaultMonospacedFontName(),
                                  getHeight() * 0.2f, juce::Font::plain));
@@ -64,11 +65,7 @@ void FourOscView::plusButtonReleased() {
     if (isShowing()) {
         if (getCurrentTabIndex() < getNumTabs() - 1) {
             setCurrentTabIndex(getCurrentTabIndex() + 1);
-            midiCommandManager.setFocusedComponent(
-                getCurrentContentComponent());
-            pageLabel.setText(juce::String(getCurrentTabIndex() + 1) + "/" +
-                                  juce::String(getNumTabs()),
-                              juce::dontSendNotification);
+            focusCurrentTab();
         }
     }
 }
@@ -77,11 +74,30 @@ void FourOscView::minusButtonReleased() {
     if (isShowing()) {
         if (getCurrentTabIndex() > 0) {
             setCurrentTabIndex(getCurrentTabIndex() - 1);
-            midiCommandManager.setFocusedComponent(
-                getCurrentContentComponent());
-            pageLabel.setText(juce::String(getCurrentTabIndex() + 1) + "/" +
-                                  juce::String(getNumTabs()),
-                              juce::dontSendNotification);
+            focusCurrentTab();
         }
     }
+}
+
+void FourOscView::currentTabChanged(int newCurrentTabIndex,
+                                    const juce::String &newCurrentTabName) {
+    juce::TabbedComponent::currentTabChanged(newCurrentTabIndex,
+                                             newCurrentTabName);
+    focusCurrentTab();
+
+    pageLabel.setText(juce::String(newCurrentTabIndex + 1) + "/" +
+                          juce::String(getNumTabs()),
+                      juce::dontSendNotification);
+}
+
+void FourOscView::visibilityChanged() {
+    juce::TabbedComponent::visibilityChanged();
+    focusCurrentTab();
+}
+
+void FourOscView::focusCurrentTab() {
+    if (!isShowing())
+        return;
+    if (auto *component = getCurrentContentComponent())
+        midiCommandManager.setFocusedComponent(component);
 }

--- a/Source/Views/Edit/Plugins/FourOsc/FourOscView.h
+++ b/Source/Views/Edit/Plugins/FourOsc/FourOscView.h
@@ -19,8 +19,13 @@ class FourOscView : public juce::TabbedComponent,
 
     void plusButtonReleased() override;
     void minusButtonReleased() override;
+    void currentTabChanged(int newCurrentTabIndex,
+                           const juce::String &newCurrentTabName) override;
+    void visibilityChanged() override;
 
   private:
+    void focusCurrentTab();
+
     tracktion::FourOscPlugin *plugin;
     app_services::MidiCommandManager &midiCommandManager;
 

--- a/Source/Views/Edit/Plugins/FourOsc/FourOscView.h
+++ b/Source/Views/Edit/Plugins/FourOsc/FourOscView.h
@@ -4,6 +4,7 @@
 #include <app_services/app_services.h>
 #include <app_view_models/app_view_models.h>
 #include <juce_gui_basics/juce_gui_basics.h>
+#include "ArpeggiatorView.h"
 
 class FourOscView : public juce::TabbedComponent,
                     public app_services::MidiCommandManager::Listener {
@@ -29,6 +30,7 @@ class FourOscView : public juce::TabbedComponent,
     juce::String osc4TabName = "OSC4";
     juce::String adsrTabName = "ADSR";
     juce::String filterTabName = "FILTER";
+    juce::String arpTabName = "ARP";
 
     AppLookAndFeel appLookAndFeel;
     juce::Label pageLabel;

--- a/Source/Views/Edit/Plugins/FourOsc/OscillatorView.h
+++ b/Source/Views/Edit/Plugins/FourOsc/OscillatorView.h
@@ -35,11 +35,14 @@ class OscillatorView : public juce::Component,
     void parametersChanged() override;
 
   private:
+    void attachSliderCallbacks();
+
     app_view_models::OscillatorViewModel viewModel;
     app_services::MidiCommandManager &midiCommandManager;
     juce::Label titleLabel;
     Knobs pluginKnobs;
     AppLookAndFeel appLookAndFeel;
+    bool sliderUpdateInProgress = false;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(OscillatorView)
 };

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -18,6 +18,16 @@ set_target_properties(gmock_main PROPERTIES FOLDER extern)
 juce_add_console_app(Tests)
 set_target_properties(Tests PROPERTIES FOLDER Tests)
 
+if (WIN32)
+  add_custom_command(TARGET Tests POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      $<TARGET_RUNTIME_DLLS:Tests>
+      $<TARGET_FILE_DIR:Tests>
+    COMMAND_EXPAND_LISTS
+  )
+endif()
+
+
 target_sources(Tests PRIVATE
         Main.cpp
         app_view_models/Edit/ItemList/ListAdapters/TracksListAdapterTest.cpp
@@ -51,7 +61,7 @@ target_link_libraries(Tests PRIVATE
         app_models
         app_view_models
         app_configuration
-        atomic
+        #atomic
         yaml-cpp
 )
 
@@ -59,4 +69,6 @@ gtest_discover_tests(Tests
         WORKING_DIRECTORY ${PROJECT_DIR}
         PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${PROJECT_DIR}"
 )
-
+if (NOT MSVC)
+  target_link_libraries(LMN-3 PRIVATE atomic)
+endif()


### PR DESCRIPTION
(Only this comment is translated using AI; my English is not very good.)

Hi David,

First of all, I would like to apologize. I realize that replying directly with a copied AI-generated message is disrespectful.

Some time ago, I developed the Load/Save Tracks functionality without using AI. It took me some time to understand the architecture, but I eventually managed to make it work.

After some time passed, I no longer remembered the architecture clearly and, a couple of weeks ago, I thought: “Hey, why not use Claude Code to see if it’s capable of implementing some LMN-3 functionality?” I suggested the arpeggiator. After a few adjustments, it implemented the feature and, when I tested it, it worked well (or almost — I had to make several tweaks until it behaved exactly as I wanted).

After seeing that it worked, I decided to submit the PR.

My mistake, and a rookie one, was assuming that the code was fine as it was, without properly checking what internal changes the AI had actually made.

So, once again, my apologies.

I have now downloaded the project from scratch and I’ll show you what I found on my own. I will not use AI anymore in this project.

I am using Visual Studio 2022, and the atomic library does not work, so I added an exception in the root CMakeLists and in the Tests folder:

if (NOT MSVC)
  target_link_libraries(LMN-3 PRIVATE atomic)
endif()


I also added the following to the root CMakeLists and the Tests folder to allow building on Windows (if this is not an issue; it is particularly useful for me when testing with the emulator):

if (WIN32)
  add_custom_command(TARGET Tests POST_BUILD
    COMMAND ${CMAKE_COMMAND} -E copy_if_different
    $<TARGET_RUNTIME_DLLS:Tests>
    $<TARGET_FILE_DIR:Tests>
    COMMAND_EXPAND_LISTS
  )
endif()


This copies yaml-cppd.dll (and any other runtime DLLs) to the directory where LMN-3.exe is located.

After doing this, the project compiles correctly and I am now aligned with the main codebase.

I found that the problem was that the AI had added the arpeggiator methods directly into
tracktion_engine/plugins/effects/tracktion_FourOscPlugin.cpp, which is incorrect, since it is not recommended to modify anything inside tracktion_engine, as it is a library that may be updated (and this is probably why you couldn’t detect the changes).

What I did instead was to create a class that extends tracktion_FourOscPlugin and implement the methods there (Source/Modules/internal_plugins/CustomFourOscPlugin). For this to work, I had to implement the OSC4 functionality inside this custom OSC4; otherwise, I would have had to modify tracktion_engine classes.

I have now added the following features:

Automatic saving of the audio output

Arpeggiator

I have successfully compiled everything locally, and the ZIP is generated correctly when running:

docker run --rm -v "$(Get-Location):/workspace" -w /workspace iamdey/lmn-3-daw-docker-compiler:arm64 bash -c "git submodule update --init --recursive && cmake -B build -DCMAKE_BUILD_TYPE=Release -DPACKAGE_TESTS=OFF -DCMAKE_TOOLCHAIN_FILE=/toolchain/toolchain.cmake && cmake --build build -j8 && cd build/LMN-3_artefacts/Release && zip -j ../../../LMN-3-aarch64-linux-gnu_0.6.3.zip LMN-3 && cd ../../../ && zip -u LMN-3-aarch64-linux-gnu_0.6.3.zip LICENSE"
pwsh .\build-local-win.ps1 -Configuration Release -Package

I hope you can now see the arpeggiator in action.


https://github.com/user-attachments/assets/5c02758f-f4ad-48e7-86f0-5e701915d795



If you agree, we can delete the New-Arpeggiator branch. I have created a new branch with everything explained above called ARPNOIA. You should no longer encounter the previous issues there.