### PR TITLE
Step Sequencer: edit clip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Step Sequencer: Edit current clip instead of creating a new one.
+
 ## [0.6.0] - 2025-11-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Step Sequencer: Edit current clip instead of creating a new one.
 
+### Fixed
+
+- Sequencer had a length of 0 on loading. It's now filled by default: 4 measures of 4 notes.
+
 ## [0.6.0] - 2025-11-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - Step Sequencer: Edit current clip instead of creating a new one.
+- Step Sequencer: Changing number of note per measure does not loop accross options anymore.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 ### Fixed
 
 - Sequencer had a length of 0 on loading. It's now filled by default: 4 measures of 4 notes.
+- When changing number of notes per measures, the midi clip stays the same instead of time stretched.
 
 ## [0.6.0] - 2025-11-20
 

--- a/Source/Modules/app_models/Sequences/StepChannel.cpp
+++ b/Source/Modules/app_models/Sequences/StepChannel.cpp
@@ -46,7 +46,7 @@ juce::BigInteger StepChannel::getPattern() {
 }
 
 /**
- * Set the note velocity between 0-7
+ * Set the note intensity between 0-7
  */
 void StepChannel::setNote(int noteIndex, int value) {
     jassert(value >= 0 && value < 8);
@@ -58,7 +58,7 @@ void StepChannel::setNote(int noteIndex, int value) {
 }
 
 /**
- * Get the note velocity between 0-7
+ * Get the note intensity between 0-7
  */
 int StepChannel::getNote(int noteIndex) {
     return getPattern().getBitRangeAsInt(noteIndex * 3, 3);

--- a/Source/Modules/app_models/Sequences/StepChannel.cpp
+++ b/Source/Modules/app_models/Sequences/StepChannel.cpp
@@ -3,9 +3,8 @@ namespace app_models {
 const int StepChannel::maxNumberOfChannels = 24;
 const int StepChannel::maxNumberOfMeasures = 4;
 /**
- * A maximum of bits for velocity dataset: 16 notes per measure × 4 measures × 3 = 192
- * bits (octal value for velocity).
- * 111 is 7 as maximum velocity
+ * A maximum of bits for velocity dataset: 16 notes per measure × 4 measures × 3
+ * = 192 bits (octal value for velocity). 111 is 7 as maximum velocity
  */
 const int StepChannel::maxNumberOfVelocityBits = 4 * 16 * 3;
 
@@ -19,8 +18,8 @@ StepChannel::StepChannel(juce::ValueTree v) : state(v) {
     std::function<juce::String(juce::String)> patternConstrainer =
         [this](juce::String param) {
             if (param.length() > maxNumberOfVelocityBits)
-                // keep only last bits: the first note index is the last 3 bits in the pattern
-                // cf. `setBitRangeAsInt`
+                // keep only last bits: the first note index is the last 3 bits
+                // in the pattern cf. `setBitRangeAsInt`
                 return param.getLastCharacters(maxNumberOfVelocityBits);
             else
                 return param;

--- a/Source/Modules/app_models/Sequences/StepChannel.cpp
+++ b/Source/Modules/app_models/Sequences/StepChannel.cpp
@@ -3,8 +3,9 @@ namespace app_models {
 const int StepChannel::maxNumberOfChannels = 24;
 const int StepChannel::maxNumberOfMeasures = 4;
 /**
- * A maximum of bits for velocity dataset: 16 notes per measure × 4 measures × 3
- * bits (octal value for velocity) 111 is 7 as maximum velocity
+ * A maximum of bits for velocity dataset: 16 notes per measure × 4 measures × 3 = 192
+ * bits (octal value for velocity).
+ * 111 is 7 as maximum velocity
  */
 const int StepChannel::maxNumberOfVelocityBits = 4 * 16 * 3;
 
@@ -18,8 +19,9 @@ StepChannel::StepChannel(juce::ValueTree v) : state(v) {
     std::function<juce::String(juce::String)> patternConstrainer =
         [this](juce::String param) {
             if (param.length() > maxNumberOfVelocityBits)
-                return param.dropLastCharacters(param.length() -
-                                                maxNumberOfVelocityBits);
+                // keep only last bits: the first note index is the last 3 bits in the pattern
+                // cf. `setBitRangeAsInt`
+                return param.getLastCharacters(maxNumberOfVelocityBits);
             else
                 return param;
         };
@@ -47,6 +49,8 @@ juce::BigInteger StepChannel::getPattern() {
 
 /**
  * Set the note intensity between 0-7
+ * noteIndex is constrained by pattern max length.
+ * cf. maxNumberOfVelocityBits: 192
  */
 void StepChannel::setNote(int noteIndex, int value) {
     jassert(value >= 0 && value < 8);

--- a/Source/Modules/app_models/Sequences/StepChannel.h
+++ b/Source/Modules/app_models/Sequences/StepChannel.h
@@ -17,11 +17,11 @@ class StepChannel {
 
     juce::BigInteger getPattern();
     /**
-     * Set the note velocity between 0 & 7
+     * Set the note intensity between 0 & 7
      */
     void setNote(int noteIndex, int value);
     /**
-     * Return the note velocity between 0 & 7
+     * Return the note intensity between 0 & 7
      */
     int getNote(int noteIndex);
     /**

--- a/Source/Modules/app_models/Sequences/StepSequence.cpp
+++ b/Source/Modules/app_models/Sequences/StepSequence.cpp
@@ -5,15 +5,24 @@ StepSequence::StepSequence(juce::ValueTree v) : state(v), channelList(v) {
 
     // if we have an empty sequence we need to initialize it
     if (channelList.isEmpty()) {
-        for (int i = 0; i < StepChannel::maxNumberOfChannels; i++) {
-            juce::ValueTree channelTree(IDs::STEP_CHANNEL);
-            channelTree.setProperty(IDs::stepChannelIndex, i, nullptr);
-            channelTree.setProperty(IDs::stepPattern, "0000000000000000",
-                                    nullptr);
-
-            state.addChild(channelTree, -1, nullptr);
-        }
+        init();
     }
+}
+
+void StepSequence::init() {
+    for (int i = 0; i < StepChannel::maxNumberOfChannels; i++) {
+        juce::ValueTree channelTree(IDs::STEP_CHANNEL);
+        channelTree.setProperty(IDs::stepChannelIndex, i, nullptr);
+        channelTree.setProperty(IDs::stepPattern, "0000000000000000",
+                                nullptr);
+
+        state.addChild(channelTree, -1, nullptr);
+    }
+}
+
+void StepSequence::clear() {
+    state.removeAllChildren(nullptr);
+    init();
 }
 
 StepChannel *StepSequence::getChannel(int index) {

--- a/Source/Modules/app_models/Sequences/StepSequence.cpp
+++ b/Source/Modules/app_models/Sequences/StepSequence.cpp
@@ -13,8 +13,7 @@ void StepSequence::init() {
     for (int i = 0; i < StepChannel::maxNumberOfChannels; i++) {
         juce::ValueTree channelTree(IDs::STEP_CHANNEL);
         channelTree.setProperty(IDs::stepChannelIndex, i, nullptr);
-        channelTree.setProperty(IDs::stepPattern, "0000000000000000",
-                                nullptr);
+        channelTree.setProperty(IDs::stepPattern, "0000000000000000", nullptr);
 
         state.addChild(channelTree, -1, nullptr);
     }

--- a/Source/Modules/app_models/Sequences/StepSequence.h
+++ b/Source/Modules/app_models/Sequences/StepSequence.h
@@ -11,8 +11,16 @@ class StepSequence {
     explicit StepSequence(juce::ValueTree v);
 
     StepChannel *getChannel(int index);
+    /**
+     * remove and init patterns
+     */
+    void clear();
 
   private:
+    /**
+     * init patterns
+     */
+    void init();
     juce::ValueTree state;
     StepChannelList channelList;
 };

--- a/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.cpp
@@ -20,6 +20,9 @@ StepSequencerViewModel::StepSequencerViewModel(tracktion::AudioTrack::Ptr t)
     // listening for that, and listen to the state directly here
     editState.addListener(this);
 
+    // set a default before introducing numberOfNotesConstrainer because it relies on it
+    notesPerMeasure.referTo(state, IDs::notesPerMeasure, nullptr, 4);
+
     std::function<int(int)> numberOfNotesConstrainer = [this](int param) {
         // numberOfNotes cannot be less than 1
         // it also cannot be greater than the maximum number of notes allowed
@@ -52,8 +55,6 @@ StepSequencerViewModel::StepSequencerViewModel(tracktion::AudioTrack::Ptr t)
 
     selectedNoteIndex.setConstrainer(selectedNoteIndexConstrainer);
     selectedNoteIndex.referTo(state, IDs::selectedNoteIndex, nullptr, 0);
-
-    notesPerMeasure.referTo(state, IDs::notesPerMeasure, nullptr, 4);
 
     std::function<int(int)> rangeIndexConstrainer = [this](int param) {
         // rangeStartIndex cannot be less than 0

--- a/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.cpp
@@ -344,7 +344,8 @@ void StepSequencerViewModel::incrementNotesPerMeasure() {
         if (currentIndex != -1) {
             int newIndex;
             if (currentIndex == notesPerMeasureOptions.size() - 1)
-                newIndex = 0;
+                // stay on the last index
+                return;
             else
                 newIndex = currentIndex + 1;
 
@@ -373,7 +374,8 @@ void StepSequencerViewModel::decrementNotesPerMeasure() {
         if (currentIndex != -1) {
             int newIndex;
             if (currentIndex == 0)
-                newIndex = notesPerMeasureOptions.size() - 1;
+                // stay on the first index
+                return;
             else
                 newIndex = currentIndex - 1;
 

--- a/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.cpp
+++ b/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.cpp
@@ -608,8 +608,9 @@ void StepSequencerViewModel::generateStepSequenceFromMidi() {
                                      NB_BEATS_PER_MEASURE);
             jassert(index >= 0);
             int intensity = computeNoteIntensity(note);
+            int channelIdx = noteNumberToChannel(noteNumber);
 
-            stepSequence.getChannel(noteNumberToChannel(noteNumber))
+            stepSequence.getChannel(channelIdx)
                 ->setNote(index, intensity);
         }
     }
@@ -670,9 +671,6 @@ StepSequencerViewModel::findNoteInSequence(int channel, int noteIndex) {
         channel + (NOTES_PER_OCTAVE * getZeroBasedOctave()) + MIN_NOTE_NUMBER;
     auto startBeat = tracktion::BeatPosition::fromBeats(
         double(noteIndex * 4.0) / double(notesPerMeasure.get()));
-    // auto duration =
-    //     tracktion::BeatDuration::fromBeats(4.0 /
-    //     double(notesPerMeasure.get()));
 
     // find the first node with matching pitch & startBeat
     for (auto note : sequence.getNotes()) {

--- a/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.h
+++ b/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.h
@@ -126,6 +126,7 @@ class StepSequencerViewModel : public juce::ValueTree::Listener,
     void valueTreePropertyChanged(juce::ValueTree &treeWhosePropertyHasChanged,
                                   const juce::Identifier &property) override;
 
+    void generateStepSequenceFromMidi();
     void generateMidiSequence();
     void addNoteToSequence(int channel, int noteIndex, int dumbVelocity);
     void removeNoteFromSequence(int channel, int noteIndex);

--- a/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.h
+++ b/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.h
@@ -21,7 +21,7 @@ class StepSequencerViewModel : public juce::ValueTree::Listener,
     int getNumChannels();
     int getNumNotesPerChannel();
 
-    int hasNoteAt(int channel, int noteIndex);
+    int noteIntensityAt(int channel, int noteIndex);
 
     void toggleNoteNumberAtSelectedIndex(int noteNumber);
 

--- a/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.h
+++ b/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.h
@@ -87,6 +87,7 @@ class StepSequencerViewModel : public juce::ValueTree::Listener,
      * Currently StepSequencer handles common 4/4 time signature.
      */
     const int NB_BEATS_PER_MEASURE = 4;
+    const int MAX_MEASURES = 4;
     /**
      * max for notesPerMeasure selector
      */

--- a/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.h
+++ b/Source/Modules/app_view_models/Edit/Sequencers/StepSequencerViewModel.h
@@ -83,6 +83,14 @@ class StepSequencerViewModel : public juce::ValueTree::Listener,
     const int MIN_OCTAVE = -4;
     const int MAX_OCTAVE = 4;
     const int NOTES_PER_OCTAVE = 12;
+    /**
+     * Currently StepSequencer handles common 4/4 time signature.
+     */
+    const int NB_BEATS_PER_MEASURE = 4;
+    /**
+     * max for notesPerMeasure selector
+     */
+    const int MAX_NOTES_PER_MEASURE = 16;
     tracktion::AudioTrack::Ptr track;
     tracktion::MidiClip::Ptr midiClip;
 
@@ -122,6 +130,14 @@ class StepSequencerViewModel : public juce::ValueTree::Listener,
     void removeNoteFromSequence(int channel, int noteIndex);
     std::optional<tracktion::MidiNote *> findNoteInSequence(int channel,
                                                             int noteIndex);
+
+    tracktion::MidiClip *editCurrentMidiClip();
+    tracktion::MidiClip *insertMidiClip();
+
+    /**
+     * Transform note velocity in intensity (between 0-7) for patterns
+     */
+    int computeNoteIntensity(tracktion::MidiNote *note);
 
     // used for transport changes
     void playbackContextChanged() override {}

--- a/Source/Views/Edit/Sequencers/StepSequencer/StepSequencerGridComponent.cpp
+++ b/Source/Views/Edit/Sequencers/StepSequencer/StepSequencerGridComponent.cpp
@@ -45,9 +45,10 @@ void StepSequencerGridComponent::paint(juce::Graphics &g) {
         float noteX = startX;
         for (int noteIndex = 0; noteIndex < viewModel.getNumNotesPerChannel();
              noteIndex++) {
-            int velocity = viewModel.hasNoteAt(channelNumber, noteIndex);
-            if (velocity > 0) {
-                float heightDiff = (7 - velocity) * rowSpacing / 10;
+            int noteIntensity =
+                viewModel.noteIntensityAt(channelNumber, noteIndex);
+            if (noteIntensity > 0) {
+                float heightDiff = (7 - noteIntensity) * rowSpacing / 10;
                 if (noteIndex < viewModel.getNumberOfNotes()) {
                     g.setColour(appLookAndFeel.yellowColour);
                     g.fillRect(noteX, channelY + heightDiff, colSpacing,

--- a/Tests/app_view_models/Edit/Sequencers/StepSequencerViewModelTest.cpp
+++ b/Tests/app_view_models/Edit/Sequencers/StepSequencerViewModelTest.cpp
@@ -25,7 +25,7 @@ TEST_F(StepSequencerViewModelTest, getNumChannels) {
 }
 
 TEST_F(StepSequencerViewModelTest, getNumNotesPerChannel) {
-    EXPECT_EQ(viewModel.getNumNotesPerChannel(), 16);
+    EXPECT_EQ(viewModel.getNumNotesPerChannel(), 64);
 }
 
 } // namespace AppViewModelsTests


### PR DESCRIPTION
## Please fill in this pull request template before submitting

### 1. Description

**Changed**

- Step Sequencer: Edit current clip instead of creating a new one.

press sequencer bouton when the transport is over clip will try to edit the clip in the sequencer:

<img width="820" height="535" alt="image" src="https://github.com/user-attachments/assets/b9d7a88a-b722-4ca1-9376-ad3d5dc1bc92" />

becomes

<img width="820" height="535" alt="image" src="https://github.com/user-attachments/assets/5644accc-f0e7-4efa-9e10-58225a7b8c11" />

- Step Sequencer: Changing number of note per measure does not loop across options anymore.

**Fixed**

- Sequencer had a length of 0 on loading. It's now filled by default: 4 measures of 4 notes.
- When changing number of notes per measures, the midi clip stays the same instead of time stretched.

<img width="820" height="535" alt="image" src="https://github.com/user-attachments/assets/cc89a872-ca1b-4515-bb08-35a4b568916e" />

become

<img width="820" height="535" alt="image" src="https://github.com/user-attachments/assets/48e1ebba-aaee-48e3-9079-48d5043eb615" />

### 2. Fill in checklist by marking [x]
- [x] I've read the CONTRIBUTING.md
- [x] My code is formatted using required linting
- [x] I've run my code locally and checked it works
- [x] My code has unit tests associated with it (if applicable)
- [x] I've run the test suite locally and all tests pass
- [x] Editing clip from an old version of a song is not breaking the clip